### PR TITLE
feat: Change branch name convention

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ description: Try to build NextJS and export site
 on:
     # Runs on pushes targeting the default branch
     pull_request:
-        branches: [ "main" ]
+        branches: [ "latest", "stable" ]
     merge_group:
         types: [checks_requested]
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,9 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "latest" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "latest", "stable" ]
   schedule:
     - cron: '23 18 * * 6'
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -12,7 +12,8 @@ name: ESLint
 on:
   push:
     branches-ignore:
-      - main
+      - latest
+      - stable
   pull_request:
 
 jobs:

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -5,7 +5,7 @@ name: Deploy site to production
 on:
     # Runs on pushes targeting the default branch
     push:
-        tags: ["production"]
+        branches: ["stable"]
         paths-ignore:
             - .*/**
             - '*.md'
@@ -85,7 +85,7 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         needs: build_production
-        if: github.ref == 'refs/tags/production'
+        if: github.ref == 'refs/heads/stable'
         environment:
             name: production
             url: https://www.versatile-thermostat.org

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -5,7 +5,7 @@ name: Deploy site to staging
 on:
     # Runs on pushes targeting the default branch
     push:
-        branches: ["main"]
+        branches: ["latest"]
         paths-ignore:
             - .*/**
             - '*.md'
@@ -87,7 +87,6 @@ jobs:
     deploy_staging:
         runs-on: ubuntu-latest
         needs: build_staging
-        if: github.ref == 'refs/heads/main'
         environment:
             name: staging
             url: https://staging.versatile-thermostat.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,18 +165,18 @@ If you set `minimal_activation_delay` on the device configuration, it's because 
 
 #### Protected Branches
 
-| Branch / tag | Purpose | Direct push |
+| Branch | Purpose | Direct push |
 |--------|---------|-------------|
-| `production` (tag) | Production-ready code | ❌ Forbidden |
-| `main` | Pre-production integration | ❌ Forbidden |
+| `stable` | Production-ready code | ❌ Forbidden |
+| `latest` | Pre-production integration | ❌ Forbidden |
 
-All changes to `main` **must go through a Pull Request** with at least **1 approved review**. Force-pushes are disabled on both branches.
+All changes to `latest` **must go through a Pull Request** with at least **1 approved review**. Force-pushes are disabled on both branches.
 
-The `production` tag is only updated on the `main` branch.
+The `stable` branch is only updated from `latest` branch or if urgent patch is needed.
 
 #### Branch Naming
 
-Create your working branch from `main` using the following convention:
+Create your working branch from `latest` using the following convention:
 
 ```
 <type>/<short-description>
@@ -193,7 +193,7 @@ Create your working branch from `main` using the following convention:
 
 #### Merge Strategy
 
-- All PRs are merged using **Squash and Merge** to keep `main` history linear and readable.
+- All PRs are merged using **Squash and Merge** to keep `latest` history linear and readable.
 - The squashed commit message must follow the [Commit Convention](#commit-convention).
 - Delete your branch after merging.
 


### PR DESCRIPTION
Change branch naming and make production tag deprecated.

We now use latest as main branch and a new branch stable to replace the production tag.
