### PR TITLE
[Plugin] Add VTherm Pellet stove

### DIFF
--- a/pluginsdb/plugins.json
+++ b/pluginsdb/plugins.json
@@ -1,0 +1,53 @@
+[
+    {
+        "name": "Adaptative TPI",
+        "description": "An integration that implements an adaptive TPI algorithm to optimize the heating system performance.",
+        "certification": "official",
+        "type": "integration",
+        "slug": "KipK/vtherm_adaptive_tpi",
+        "family": "algorithm"
+    },
+    {
+        "slug": "jmcollin78/versatile-thermostat-ui-card",
+        "name": "Versatile Card UI",
+        "description": "Versatile thermostat control dashboard card.",
+        "type": "interface",
+        "certification": "official",
+        "family": "interface"
+    },
+    {
+        "name": "VTherm climate replication",
+        "description": "<p>VTherm Climate Replication is a Home Assistant custom integration for Versatile Thermostat.</p><p>It links a physical thermostat entity to a Versatile Thermostat climate entity and forwards the physical thermostat state changes to the target VTherm. The goal is to use a real thermostat as a physical remote control for a VTherm.</p>",
+        "certification": "official",
+        "type": "integration",
+        "slug": "jmcollin78/vtherm_climate_replication",
+        "author": "jmcollin78",
+        "family": "device-helper"
+    },
+    {
+        "slug": "KipK/ha_entity_explorer",
+        "name": "HA Entity Explorer",
+        "description": "Dashboard with all Home Assistant statuses.",
+        "type": "addon",
+        "certification": "recommended",
+        "family": "interface"
+    },
+    {
+        "name": "Sonoff TRVZB linearity",
+        "author": "Caius",
+        "description": "Blueprint for fine-tuning TRVZB valves and adjusting the opening to the valve linearity, which is often non-linear. This blueprint allows you to create a linear relationship between the valve opening and the actual flow, improving the performance of the heating system.",
+        "type": "blueprint",
+        "certification": "recommended",
+        "url": "https://gist.githubusercontent.com/caiusseverus/abe064b3f8d96896ab377766916e456a/raw/LinearTRV.yaml",
+        "family": "device-helper"
+    },
+    {
+        "name": "VTherm Pellet stove",
+        "description": "<p>This plugin for Home Assistant is designed to control your pellet stove. Create an <code>over_switch</code> VTherm and link it to this integration to have special regulation algorithm specially designed for pellet stove.</p>",
+        "certification": "community",
+        "type": "integration",
+        "family": "algorithm",
+        "slug": "jmcollin78/vtherm_pellet_stove",
+        "author": "jmcollin78"
+    }
+]


### PR DESCRIPTION
Closes #80

Adds the **VTherm Pellet stove** plugin (`integration`) to the database.

| Field | Value |
|-------|-------|
| Name | VTherm Pellet stove |
| Type | integration |
| Family | algorithm |
| Certification | community |
| Slug | `jmcollin78/vtherm_pellet_stove` |
| GitHub URL | https://github.com/jmcollin78/vtherm_pellet_stove |

> ⚠️ The certification level is set to `community` by default.
> A maintainer can upgrade it after review.