### PR TITLE
[Plugin] Add VTherm Pellet stove

### DIFF
--- a/pluginsdb/plugins.json
+++ b/pluginsdb/plugins.json
@@ -16,6 +16,15 @@
         "family": "interface"
     },
     {
+        "name": "VTherm climate replication",
+        "description": "<p>VTherm Climate Replication is a Home Assistant custom integration for Versatile Thermostat.</p><p>It links a physical thermostat entity to a Versatile Thermostat climate entity and forwards the physical thermostat state changes to the target VTherm. The goal is to use a real thermostat as a physical remote control for a VTherm.</p>",
+        "certification": "official",
+        "type": "integration",
+        "slug": "jmcollin78/vtherm_climate_replication",
+        "author": "jmcollin78",
+        "family": "device-helper"
+    },
+    {
         "slug": "KipK/ha_entity_explorer",
         "name": "HA Entity Explorer",
         "description": "Dashboard with all Home Assistant statuses.",
@@ -33,12 +42,12 @@
         "family": "device-helper"
     },
     {
-        "name": "VTherm climate replication",
-        "description": "<p>VTherm Climate Replication is a Home Assistant custom integration for Versatile Thermostat.</p><p>It links a physical thermostat entity to a Versatile Thermostat climate entity and forwards the physical thermostat state changes to the target VTherm. The goal is to use a real thermostat as a physical remote control for a VTherm.</p>",
-        "certification": "official",
+        "name": "VTherm Pellet stove",
+        "description": "<p>This plugin for Home Assistant is designed to control your pellet stove. Create an <code>over_switch</code> VTherm and link it to this integration to have special regulation algorithm specially designed for pellet stove.</p>",
+        "certification": "community",
         "type": "integration",
-        "slug": "jmcollin78/vtherm_climate_replication",
-        "author": "jmcollin78",
-        "family": "device-helper"
+        "family": "algorithm",
+        "slug": "jmcollin78/vtherm_pellet_stove",
+        "author": "jmcollin78"
     }
 ]

--- a/pluginsdb/plugins.json
+++ b/pluginsdb/plugins.json
@@ -46,7 +46,7 @@
         "description": "<p>This plugin for Home Assistant is designed to control your pellet stove. Create an <code>over_switch</code> VTherm and link it to this integration to have special regulation algorithm specially designed for pellet stove.</p>",
         "certification": "community",
         "type": "integration",
-        "family": "algorithm",
+        "family": "device-helper",
         "slug": "jmcollin78/vtherm_pellet_stove",
         "author": "jmcollin78"
     }


### PR DESCRIPTION
Closes #80

Adds the **VTherm Pellet stove** plugin (`integration`) to the database.

| Field | Value |
|-------|-------|
| Name | VTherm Pellet stove |
| Type | integration |
| Family | algorithm |
| Certification | community |
| Slug | `jmcollin78/vtherm_pellet_stove` |
| GitHub URL | https://github.com/jmcollin78/vtherm_pellet_stove |

> ⚠️ The certification level is set to `community` by default.
> A maintainer can upgrade it after review.