### PR TITLE
[Plugin] Add Vtherm-Hysteresis

### DIFF
--- a/pluginsdb/plugins.json
+++ b/pluginsdb/plugins.json
@@ -50,5 +50,14 @@
         "family": "device-helper",
         "slug": "jmcollin78/vtherm_pellet_stove",
         "author": "jmcollin78"
+    },
+    {
+        "name": "Vtherm-Hysteresis",
+        "description": "<p>This integration provides a simple hysteresis-based heating algorithm packaged as an external integration for Versatile Thermostat.</p>\n<p>This repository also serve as project scaffold for Vtherm plugins development.</p>",
+        "certification": "community",
+        "type": "integration",
+        "family": "algorithm",
+        "slug": "KipK/vtherm_hysteresis",
+        "author": "KipK"
     }
 ]


### PR DESCRIPTION
Closes #78

Adds the **Vtherm-Hysteresis** plugin (`integration`) to the database.

| Field | Value |
|-------|-------|
| Name | Vtherm-Hysteresis |
| Type | integration |
| Family | algorithm |
| Certification | community |
| Slug | `KipK/vtherm_hysteresis` |
| GitHub URL | https://github.com/KipK/vtherm_hysteresis |

> ⚠️ The certification level is set to `community` by default.
> A maintainer can upgrade it after review.